### PR TITLE
test(property-picker): fix jest.runAllTimers infinite recursion  error

### DIFF
--- a/src/property-selector/__test__/PropertyPicker.test.tsx
+++ b/src/property-selector/__test__/PropertyPicker.test.tsx
@@ -82,7 +82,8 @@ describe('PropertyPicker', () => {
     expect(screen.queryByText(insightDimensions[0].id)).toBeTruthy();
 
     // screen.debug(screen.queryByText(insightDimensions[0].id));
-    // fireEvent.mouseLeave(item);
+    fireEvent.mouseLeave(item);
+    expect(screen.queryByText(insightDimensions[0].id)).toBeNull();
   });
 
   it('can search a property by name', () => {


### PR DESCRIPTION
When using fake timers,  calling jest.runAllTimers, an error will be printed:
FAIL src/property-selector/__test__/PropertyPicker.test.tsx (16.229 s)
  ● PropertyPicker › can hover a property and show the detail of property
Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out...

