### PR TITLE
style(tablecard): style error

### DIFF
--- a/src/table-card/style/index.less
+++ b/src/table-card/style/index.less
@@ -64,6 +64,7 @@
       height: 14px;
       width: 14px;
       padding: 8px;
+      box-sizing: content-box;
     }
     &-divider {
       display: inline-block;


### PR DESCRIPTION
当box-sizing设置为border-box时，已选x项错位。